### PR TITLE
Feat/api study 스터디목록조회 - reaction 추가

### DIFF
--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -2,12 +2,26 @@ import prisma from "../prismaClient.js";
 import { studies } from "./seeds/seed.study.js";
 
 async function main() {
+  await prisma.reaction.deleteMany({});
   await prisma.study.deleteMany({});
 
   for (const study of studies) {
-    await prisma.study.create({
-      data: study,
+    const { reactions, ...studyData } = study;
+
+    const createdStudy = await prisma.study.create({
+      data: studyData,
     });
+
+    if (reactions) {
+      for (const reaction of reactions) {
+        await prisma.reaction.create({
+          data: {
+            ...reaction,
+            studyId: createdStudy.id,
+          },
+        });
+      }
+    }
   }
 
   console.log("시드 데이터가 성공적으로 생성되었습니다.");

--- a/prisma/seeds/seed.study.js
+++ b/prisma/seeds/seed.study.js
@@ -4,55 +4,121 @@ export const studies = [
     password: "password123",
     description: "매주 알고리즘 문제를 함께 풀어보는 스터디입니다.",
     backgroundImageUrl: "https://example.com/images/algorithm.jpg",
-    point: 100,
+    points: 100,
     createdAt: new Date("2024-01-01"),
+    reactions: [
+      {
+        emoji: "👍",
+        counts: 5,
+      },
+      {
+        emoji: "🔥",
+        counts: 3,
+      },
+    ],
   },
   {
     name: "리액트 스터디",
     password: "password123",
     description: "리액트와 Next.js를 학습하는 스터디입니다.",
     backgroundImageUrl: "https://example.com/images/react.jpg",
-    point: 150,
+    points: 150,
     createdAt: new Date("2024-02-01"),
+    reactions: [
+      {
+        emoji: "❤️",
+        counts: 7,
+      },
+    ],
   },
   {
     name: "파이썬 기초 스터디",
     password: "password123",
     description: "파이썬 기초부터 차근차근 배워보아요",
     backgroundImageUrl: "https://example.com/images/python.jpg",
-    point: 80,
+    points: 80,
     createdAt: new Date("2024-03-01"),
+    reactions: [
+      {
+        emoji: "🐍",
+        counts: 4,
+      },
+      {
+        emoji: "👏",
+        counts: 2,
+      },
+    ],
   },
   {
     name: "코딩 테스트 대비",
     password: "password123",
     description: "기업 코딩 테스트 준비를 위한 스터디",
     backgroundImageUrl: "https://example.com/images/coding-test.jpg",
-    point: 120,
+    points: 120,
     createdAt: new Date("2024-03-15"),
+    reactions: [
+      {
+        emoji: "💪",
+        counts: 6,
+      },
+      {
+        emoji: "🎯",
+        counts: 3,
+      },
+    ],
   },
   {
     name: "자바스크립트 심화",
     password: "password123",
     description: "자바스크립트 고급 개념 학습 스터디",
     backgroundImageUrl: "https://example.com/images/javascript.jpg",
-    point: 200,
+    points: 200,
     createdAt: new Date("2024-03-20"),
+    reactions: [
+      {
+        emoji: "🚀",
+        counts: 8,
+      },
+      {
+        emoji: "⭐",
+        counts: 5,
+      },
+    ],
   },
   {
     name: "데이터베이스 실습",
     password: "password123",
     description: "SQL과 NoSQL 데이터베이스 학습",
     backgroundImageUrl: "https://example.com/images/database.jpg",
-    point: 90,
+    points: 90,
     createdAt: new Date("2024-03-25"),
+    reactions: [
+      {
+        emoji: "💾",
+        counts: 3,
+      },
+      {
+        emoji: "📊",
+        counts: 2,
+      },
+    ],
   },
   {
     name: "웹 보안 스터디",
     password: "password123",
     description: "웹 보안과 관련된 개념을 학습합니다.",
     backgroundImageUrl: "https://example.com/images/security.jpg",
-    point: 180,
+    points: 180,
     createdAt: new Date("2024-03-30"),
+    reactions: [
+      {
+        emoji: "🔒",
+        counts: 5,
+      },
+      {
+        emoji: "🛡️",
+        counts: 4,
+      },
+    ],
   },
 ];

--- a/router/studies/study.service.js
+++ b/router/studies/study.service.js
@@ -41,6 +41,14 @@ export const fetchAllStudies = async (
     orderBy,
     skip,
     take,
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      points: true,
+      createdAt: true,
+      updatedAt: true,
+    },
   });
 
   const total = await prisma.study.count({ where });

--- a/router/studies/study.service.js
+++ b/router/studies/study.service.js
@@ -45,8 +45,23 @@ export const fetchAllStudies = async (
 
   const total = await prisma.study.count({ where });
 
+  const studyIds = studies.map((study) => study.id);
+
+  const reactions = await prisma.reaction.findMany({
+    where: {
+      studyId: {
+        in: studyIds,
+      },
+    },
+  });
+
+  const studiesWithReactions = studies.map((study) => ({
+    ...study,
+    reactions: reactions.filter((reaction) => reaction.studyId === study.id),
+  }));
+
   return {
-    studies,
+    studies: studiesWithReactions,
     total,
     currentPage: Number(page),
     totalPages: Math.ceil(total / Number(pageSize)),

--- a/test.js
+++ b/test.js
@@ -1,0 +1,12 @@
+const fetchedStudies = await prisma.study.findMany();
+for (const reaction of reactions) {
+  let studyId = "";
+  let idx = 0;
+  let cnt = 0;
+  if (fetchedStudies.length > idx) studyId = fetchedStudies[idx].id;
+  await prisma.reaction.create({
+    data: { ...reaction, studyId },
+  });
+  cnt += 1;
+  if (cnt === 4) idx += 1;
+}


### PR DESCRIPTION
## 📌 개요

- 이미 develop으로 merge 완료된 스터디 목록에서 reation 스키마에 있는 emoji 와 counts가 필요한 부분이 누락되어서 추가

## ✨ 주요 변경 사항

- 스키마를 수정하지 않고 study service에 reaction 관련 로직을 추가하여 스터디 조회 시 정보를 추가로 받아온다.

## 공유 사항(다른 팀원들도 알아두어야 할 것들)

- 기존 스키마를 수정하고( reaction에 studyId에 외래키 설정) 하는 방식을 사용하는 것도 생각해 보야야 할 듯 합니다.
- 테스트를 위해 임의로 studies에 reation 배열을 넣는 방식으로 seed data를 삽입하였습니다.

## 🔗 관련 이슈

