### PR TITLE
feat: 최근 조회한 스터디 목록 조회 api

### DIFF
--- a/prisma/seeds/seed.dailyHabitChecks.js
+++ b/prisma/seeds/seed.dailyHabitChecks.js
@@ -1,30 +1,30 @@
 export const dailyHabitChecks = [
   {
-    habitId: 'test',
-    date: new Date('2025-02-05'),
+    habitId: "test",
+    date: new Date("2025-02-05"),
   },
   {
-    habitId: 'test',
-    date: new Date('2025-02-04'),
+    habitId: "test",
+    date: new Date("2025-02-04"),
   },
   {
-    habitId: 'test',
-    date: new Date('2025-02-03'),
+    habitId: "test",
+    date: new Date("2025-02-03"),
   },
   {
-    habitId: 'test',
-    date: new Date('2025-02-06'),
+    habitId: "test",
+    date: new Date("2025-02-06"),
   },
   {
-    habitId: 'test',
-    date: new Date('2025-02-07'),
+    habitId: "test",
+    date: new Date("2025-02-07"),
   },
   {
-    habitId: 'test',
-    date: new Date('2025-02-08'),
+    habitId: "test",
+    date: new Date("2025-02-08"),
   },
   {
-    habitId: 'hello',
-    date: new Date('2025-02-04'),
+    habitId: "hello",
+    date: new Date("2025-02-04"),
   },
 ];

--- a/router/studies/index.js
+++ b/router/studies/index.js
@@ -6,21 +6,22 @@ import {
   modifyStudy,
   removeStudy,
   fetchStudyDetail,
+  fetchRecentStudies,
 } from "./study.controller.js";
 
 import habitRouter from "../habits/index.js";
 import reactionRouter from "../reactions/index.js";
 import pointRouter from "../points/index.js";
 
-
 const router = express.Router();
 
 router.get("/", fetchAllStudies);
 router.post("/", addStudy);
+router.get("/recent", fetchRecentStudies);
+router.post("/verify-password", verifyPassword);
 router.get("/:studyId", fetchStudyDetail);
 router.patch("/:studyId", modifyStudy);
 router.delete("/:studyId", removeStudy);
-router.post("/verify-password", verifyPassword);
 
 router.use("/:studyId/habits", habitRouter);
 router.use("/:studyId/reactions", reactionRouter);

--- a/router/studies/study.controller.js
+++ b/router/studies/study.controller.js
@@ -146,3 +146,21 @@ export const fetchStudyDetail = async (req, res) => {
       .send({ error: "스터디 상세 정보를 가져오는데 실패했습니다." });
   }
 };
+
+/// 최근 조회한 스터디 목록 조회
+export const fetchRecentStudies = async (req, res) => {
+  const { studyIds } = req.query;
+
+  try {
+    // 쿼리 파라미터로 받은 문자열을 배열로 변환
+    const studyIdArray = studyIds ? studyIds.split(",") : [];
+
+    const result = await studyService.fetchRecentStudies(studyIdArray);
+    res.status(200).send(result);
+  } catch (err) {
+    console.error("최근 조회한 스터디 목록 조회 중 오류 발생", err);
+    res.status(500).send({
+      error: "최근 조회한 스터디 목록을 가져오는데 실패했습니다.",
+    });
+  }
+};

--- a/router/studies/study.service.js
+++ b/router/studies/study.service.js
@@ -232,6 +232,55 @@ export const fetchStudyDetail = async (studyId) => {
   };
 };
 
+/// 최근 조회한 스터디 목록 조회
+export const fetchRecentStudies = async (studyIds) => {
+  if (!studyIds || studyIds.length === 0) {
+    return {
+      studies: [],
+      total: 0,
+    };
+  }
+
+  const studies = await prisma.study.findMany({
+    where: {
+      id: { in: studyIds },
+    },
+    select: {
+      id: true,
+      nickname: true,
+      title: true,
+      description: true,
+      totalPoints: true,
+      backgroundType: true,
+      backgroundContent: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+
+  const reactions = await prisma.reaction.findMany({
+    where: {
+      studyId: { in: studyIds },
+    },
+    orderBy: { counts: "desc" },
+  });
+
+  const studiesWithReactions = studies.map((study) => {
+    const studyReactions = reactions
+      .filter((reaction) => reaction.studyId === study.id)
+      .slice(0, 3);
+    return {
+      ...study,
+      reactions: studyReactions,
+    };
+  });
+
+  return {
+    studies: studiesWithReactions,
+    total: studies.length,
+  };
+};
+
 const studyService = {
   fetchAllStudies,
   addStudy,
@@ -240,6 +289,7 @@ const studyService = {
   modifyStudy,
   existStudyById,
   fetchStudyDetail,
+  fetchRecentStudies,
 };
 
 export default studyService;


### PR DESCRIPTION
## 📌 개요

- 프론트의 요구로 추가 엔드포인트 api를 추가하였습니다.

## ✨ 주요 변경 사항

- 

## 공유 사항(다른 팀원들도 알아두어야 할 것들)

- 엔드포인트 : ```/api/studies/recent```
- Query Parameters:
studyIds: 콤마(,)로 구분된 스터디 ID string
예: studyIds=uuid1,uuid2,uuid3
- studyIds 쿼리 파라미터가 없거나 빈 문자열인 경우 빈 배열과 함께 total: 0을 반환합니다.

## 🔗 관련 이슈

-
