### PR TITLE
refactor: utc2kst 테스트 필요함

### DIFF
--- a/prismaClient.js
+++ b/prismaClient.js
@@ -19,12 +19,13 @@ prisma.$use(async (params, next) => {
       case "create":
         params.args.data.createdAt ??= nowKST;
         params.args.data.updatedAt ??= nowKST;
+
         if (params.model === "FocusPointLogs") {
           params.args.data.startedAt = new Date(
-            params.args.data.startedAt + KST_OFFSET
+            new Date(params.args.data.startedAt).getTime() + KST_OFFSET
           );
           params.args.data.finishedAt = new Date(
-            params.args.data.finishedAt + KST_OFFSET
+            new Date(params.args.data.finishedAt).getTime() + KST_OFFSET
           );
         }
         break;
@@ -32,7 +33,7 @@ prisma.$use(async (params, next) => {
         params.args.data.updatedAt ??= nowKST;
         if (params.model === "Habit") {
           params.args.data.deletedAt = new Date(
-            params.args.data.deletedAt + KST_OFFSET
+            new Date(params.args.data.deletedAt).getTime() + KST_OFFSET
           );
         }
         break;
@@ -42,7 +43,7 @@ prisma.$use(async (params, next) => {
           params.args.create.updatedAt ??= nowKST;
           if (params.model === "dailyHabitCheck") {
             params.args.data.date = new Date(
-              params.args.data.date + KST_OFFSET
+              new Date(params.args.data.date).getTime() + KST_OFFSET
             );
           }
         }

--- a/prismaClient.js
+++ b/prismaClient.js
@@ -30,6 +30,11 @@ prisma.$use(async (params, next) => {
         break;
       case "update":
         params.args.data.updatedAt ??= nowKST;
+        if (params.model === "Habit") {
+          params.args.data.deletedAt = new Date(
+            params.args.data.deletedAt + KST_OFFSET
+          );
+        }
         break;
       case "upsert":
         if (params.args.create) {


### PR DESCRIPTION
## 📌 개요

- `FocusPointLogs`, `dailyHabitCheck` 스키마의 날짜 컬럼이 UTC로 저장되는 것을 KST로 변환

## ✨ 주요 변경 사항

- `prismaClient.js` 수정

## 공유 사항(다른 팀원들도 알아두어야 할 것들)

- 포인트 부여 API `POST /api/studies/{studyId}/points`의 `startedAt`, `finishedAt`은 DateTime으로 전달

## 🔗 관련 이슈

- #62 
