### PR TITLE
fix: 바디파라미터 counts를 결과값에서 증가시킬값으로 수정

### DIFF
--- a/router/reactions/reaction.service.js
+++ b/router/reactions/reaction.service.js
@@ -26,7 +26,7 @@ const addReaction = async (data) => {
 const modifyReactionById = async ({ reactionId, counts }) => {
   return await prisma.reaction.update({
     where: { id: reactionId },
-    data: { counts },
+    data: { counts: { increment: counts } },
     select: {
       id: true,
       emoji: true,


### PR DESCRIPTION
## 📌 개요

- 현재 PATCH /api/studies/{studyId}/reactions/{reactionId} API는
요청 바디 파라미터로 counts의 결과 받아서 db에 업데이트를 진행함.

이 부분 변경이 필요함.
counts의 결과를 받는 것이 아니라, 증가값을 받아야 함.

이유

결과값을 받으면, db에 저장되는 카운터의 결과가 신뢰성을 잃음
예를 들어:
초기 카운터가 10인 이모지가 있음
두 명이 각각 10번 누름
최종적으로 30이 되어야 하지만, 처리에 따라 20이 될 수 있음

## ✨ 주요 변경 사항

- 바디 파라미터 `counts`의 결과를 받는 것이 아니라, 증가값을 받아야 함.

## 공유 사항(다른 팀원들도 알아두어야 할 것들)

-

## 🔗 관련 이슈

- #65 
